### PR TITLE
select cell支持options内部元素格式为对象格式

### DIFF
--- a/components/cells/cell-select.vue
+++ b/components/cells/cell-select.vue
@@ -1,6 +1,6 @@
 <template>
 <select class="weui_select" v-model="selected">
-  <option v-for="option in options">{{option}}</option>
+  <option v-for="option in translatedOptions" :value="option.value">{{option.text}}</option>
 </select>
 </template>
 
@@ -12,9 +12,25 @@ export default {
       required: true,
       twoWay: true
     },
+
     options: {
       type: Array,
       required: true
+    }
+  },
+
+  computed: {
+    translatedOptions() {
+      return this.options.map(option => {
+        if (typeof option === 'string') {
+          return {
+            value: option,
+            text: option
+          };
+        } else {
+          return option
+        }
+      });
     }
   }
 }

--- a/components/cells/select-cell.vue
+++ b/components/cells/select-cell.vue
@@ -21,6 +21,8 @@ export default {
   props: {
     /**
      * 选项数组
+     * 支持纯字符串格式和包含value、text字段的对象格式
+     * 若为纯字符串，则该项的value和text均为该字符串
      */
     options: {
       type: Array,
@@ -29,7 +31,6 @@ export default {
 
     /**
      * 选中项数据绑定，会用于select的v-model
-     * @type {Object}
      */
     selected: {
       type: null,

--- a/docs/components.md
+++ b/docs/components.md
@@ -481,6 +481,8 @@ maxlength: {
 ```javascript
 /**
  * 选项数组
+ * 支持纯字符串格式和包含value、text字段的对象格式
+ * 若为纯字符串，则该项的value和text均为该字符串
  */
 options: {
   type: Array,

--- a/examples/containers/cell.vue
+++ b/examples/containers/cell.vue
@@ -171,7 +171,13 @@ export default {
       areaCodeOptions: ['+86', '+80', '+84', '+87'],
       areaCodeSelected: '+86',
       phoneValue: '',
-      contactTypeOptions: ['微信号', 'QQ号', 'Email'],
+      contactTypeOptions: [
+        '微信号',
+        {
+          value: 'qq',
+          text: 'QQ号'
+        },
+        'Email'],
       contactTypeSelected: '微信号',
       nationOptions: ['中国', '美国', '英国'],
       nationSelected: '中国',


### PR DESCRIPTION
目前，可支持如下格式的options

``` javascript
contactTypeOptions: [
  '微信号',
  {
    value: 'qq',
    text: 'QQ号'
  },
  'Email'
]
```
